### PR TITLE
see comments

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,0 +1,61 @@
+(function($) {
+	"use strict"
+
+	///////////////////////////
+	// Preloader
+	$(window).on('load', function() {
+		$("#preloader").delay(600).fadeOut();
+	});
+
+	///////////////////////////
+	// Scrollspy
+	$('body').scrollspy({
+		target: '#nav',
+		offset: $(window).height() / 2
+	});
+
+	///////////////////////////
+	// Smooth scroll
+	$("#nav .main-nav a[href^='#']").on('click', function(e) {
+		e.preventDefault();
+		var hash = this.hash;
+		$('html, body').animate({
+			scrollTop: $(this.hash).offset().top
+		}, 600);
+	});
+
+	$('#back-to-top').on('click', function(){
+		$('body,html').animate({
+			scrollTop: 0
+		}, 600);
+	});
+
+	///////////////////////////
+	// Btn nav collapse
+	$('#nav .nav-collapse').on('click', function() {
+		$('#nav').toggleClass('open');
+	});
+
+	///////////////////////////
+	// Mobile dropdown
+	$('.has-dropdown a').on('click', function() {
+		$(this).parent().toggleClass('open-drop');
+	});
+
+	///////////////////////////
+	// On Scroll
+	$(window).on('scroll', function() {
+		const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+		var wScroll = $(this).scrollTop();
+
+		// Fixed nav
+		wScroll <= viewportHeight ? $('#nav').addClass('fixed-tweak') : $('#nav').removeClass('fixed-tweak');
+		wScroll > viewportHeight ? $('#nav').addClass('fixed-nav') : $('#nav').removeClass('fixed-nav');
+
+
+		// Back To Top Appear
+		wScroll > 700 ? $('#back-to-top').fadeIn() : $('#back-to-top').fadeOut();
+	});
+
+
+})(jQuery);

--- a/public/js/subpage.js
+++ b/public/js/subpage.js
@@ -45,11 +45,12 @@
 	///////////////////////////
 	// On Scroll
 	$(window).on('scroll', function() {
+		const viewportHeight = (Math.max(document.documentElement.clientHeight, window.innerHeight || 0) * 0.70);
 		var wScroll = $(this).scrollTop();
 
 		// Fixed nav
-		wScroll <= 599 ? $('#nav').addClass('fixed-tweak') : $('#nav').removeClass('fixed-tweak');
-		wScroll > 599 ? $('#nav').addClass('fixed-nav') : $('#nav').removeClass('fixed-nav');
+		wScroll <= viewportHeight ? $('#nav').addClass('fixed-tweak') : $('#nav').removeClass('fixed-tweak');
+		wScroll > viewportHeight ? $('#nav').addClass('fixed-nav') : $('#nav').removeClass('fixed-nav');
 
 
 		// Back To Top Appear

--- a/routes/htmlRoutes.js
+++ b/routes/htmlRoutes.js
@@ -13,13 +13,12 @@ module.exports = (app) => {
   app.get('/:page', (req, res) => {
     const page = req.params.page;
     switch(page) {
-      case ('services'):
-        return res.render('services');
       case ('equipment'):
         return db.Equipment.findAll({
           raw: true
         }).then((equipment) => {
           res.render('equipment', {
+            layout: "subpage.handlebars",
             equipment: equipment
           });
         });
@@ -33,7 +32,9 @@ module.exports = (app) => {
           });
         });
       case ('contact'):
-        return res.render('contact');
+        return res.render('contact', {
+          layout: "subpage.handlebars"
+        });
       default:
         return res.render('404', {layout: false})
     }

--- a/views/clients.handlebars
+++ b/views/clients.handlebars
@@ -190,7 +190,7 @@
 	src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" 
 	integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" 
 	crossorigin="anonymous"></script>
-	<script type="text/javascript" src="/js/main.js"></script>
+	<script type="text/javascript" src="/js/subpage.js"></script>
 	<script type="text/javascript" src="/js/contact.js"></script>
 	{{!-- /jQuery & Bootstrap --}}
 </body>

--- a/views/layouts/subpage.handlebars
+++ b/views/layouts/subpage.handlebars
@@ -70,7 +70,7 @@
 	src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" 
 	integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" 
 	crossorigin="anonymous"></script>
-	<script type="text/javascript" src="/js/index.js"></script>
+	<script type="text/javascript" src="/js/subpage.js"></script>
 	<script type="text/javascript" src="/js/contact.js"></script>
 	{{!-- /jQuery & Bootstrap --}}
 </body>


### PR DESCRIPTION
Had to update multiple files to fix the header transparency issue.  Use JS to determine the viewport height and then adjusted the on scroll to adjust based on this value.  On non-index pages this is adjusted to 70% of the value due to the size of the header image.

Did a quick fix due to timing to get this implemented by creating a new JS file and adjusting the routing templates to use this new file. Works well of the viewports I tested.

Needs to be improved in the future to transition smoothly. There is what appears to be a dead zone which can be fixed with a small animation.